### PR TITLE
fix for LZW36 fan entities

### DIFF
--- a/scripts/notifications/inovelli_led/inovelli_led.yaml
+++ b/scripts/notifications/inovelli_led/inovelli_led.yaml
@@ -126,7 +126,12 @@ sequence:
                 {%- if "LZW31" in model_name %}
                   dimmer
                 {%- elif "LZW36" in model_name %}
-                  combo_light
+                  {%- set domain = repeat.item.split(".")[0] %}
+                  {%- if domain == "fan" %}
+                    combo_fan
+                  {%- else %}
+                    combo_light
+                  {%- endif %}
                 {%- else %}
                   switch
                 {%- endif %}
@@ -195,6 +200,7 @@ fields:
         domain:
           - light
           - switch
+          - fan
         integration: zwave_js
         multiple: true
   color:


### PR DESCRIPTION
Include LZW36 fan entities.

Credit: https://community.home-assistant.io/t/inovelli-z-wave-red-series-notification-led/165483/179
